### PR TITLE
Take Locale from configuration.

### DIFF
--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/common/domain/Extensions.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/common/domain/Extensions.kt
@@ -16,7 +16,10 @@
 
 package com.marosseleng.compose.material3.datetimepickers.common.domain
 
+import android.content.res.Configuration
+import android.os.Build
 import androidx.compose.ui.Modifier
+import java.util.Locale
 import kotlin.math.abs
 import kotlin.math.roundToInt
 
@@ -36,7 +39,7 @@ internal fun Float.roundToNearest(increment: Float): Float {
 /**
  * Calls the given [callback] only if [obj] is not `null`.
  */
-public fun <T : Any?> Modifier.withNotNull(obj: T, callback: Modifier.(T & Any) -> Modifier): Modifier {
+internal fun <T : Any?> Modifier.withNotNull(obj: T, callback: Modifier.(T & Any) -> Modifier): Modifier {
     return if (obj == null) {
         this
     } else {
@@ -44,10 +47,17 @@ public fun <T : Any?> Modifier.withNotNull(obj: T, callback: Modifier.(T & Any) 
     }
 }
 
-public fun Modifier.applyIf(condition: Boolean, callback: Modifier.() -> Modifier): Modifier {
-    return if (condition) {
-        this.callback()
+/**
+ * Returns the preferred [Locale] for user-visible strings.
+ */
+internal fun Configuration.getDefaultLocale(): Locale {
+    return if (Build.VERSION.SDK_INT < Build.VERSION_CODES.N) {
+        locale
     } else {
-        this
-    }
+        if (locales.isEmpty) {
+            Locale.getDefault()
+        } else {
+            locales.get(0)
+        }
+    } ?: Locale.getDefault()
 }

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
@@ -191,7 +191,7 @@ internal fun ModalDatePicker(
                         MonthSelection(
                             modifier = Modifier
                                 .heightIn(max = 336.dp),
-                            locale = LocalConfiguration.current.getDefaultLocale(),
+                            locale = locale,
                             selectedMonth = yearMonth.month,
                             onMonthClick = {
                                 yearMonth = YearMonth.of(yearMonth.year, it)

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
@@ -211,7 +211,7 @@ internal fun ModalDatePicker(
  *
  * @param selectedMonth the currently selected [Month]
  * @param onMonthClick called when a month is clicked
-§ * @param locale [Locale] for formatting [selectedMonth] and other [Month]s
+ * @param locale [Locale] for formatting [selectedMonth] and other [Month]s
  * @param modifier a [Modifier]
  */
 @Composable

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
@@ -149,6 +149,7 @@ internal fun ModalDatePicker(
                     }
                 },
                 onNextMonthClick = { yearMonth = yearMonth.plusMonths(1L) },
+                locale = locale,
                 modifier = Modifier.offset(x = -16.dp),
             )
 
@@ -210,15 +211,15 @@ internal fun ModalDatePicker(
  *
  * @param selectedMonth the currently selected [Month]
  * @param onMonthClick called when a month is clicked
+§ * @param locale [Locale] for formatting [selectedMonth] and other [Month]s
  * @param modifier a [Modifier]
- * @param locale [Locale] for formatting [selectedMonth] and other [Month]s
  */
 @Composable
 internal fun MonthSelection(
     selectedMonth: Month,
     onMonthClick: (Month) -> Unit,
+    locale: Locale,
     modifier: Modifier = Modifier,
-    locale: Locale = LocalConfiguration.current.getDefaultLocale()
 ) {
     val months by remember(Unit) {
         mutableStateOf(Month.values().map { it.getDisplayName(TextStyle.FULL_STANDALONE, locale) })
@@ -288,7 +289,7 @@ internal fun MonthSelection(
 internal fun YearSelection(
     selectedYear: Int,
     onYearClick: (Int) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
 ) {
     val lazyListState = rememberLazyListState()
 
@@ -368,8 +369,8 @@ internal fun YearSelection(
  * @param onPreviousMonthClick called when clicked on the "previous month" arrow
  * @param onMonthClick called when clicked on the current month
  * @param onNextMonthClick called when clicked on the "next month" arrow
- * @param modifier a [Modifier]
  * @param locale [Locale] for formatting [currentYearMonth]
+ * @param modifier a [Modifier]
  */
 @Composable
 internal fun MonthYearSelection(
@@ -378,8 +379,8 @@ internal fun MonthYearSelection(
     onPreviousMonthClick: () -> Unit,
     onMonthClick: () -> Unit,
     onNextMonthClick: () -> Unit,
+    locale: Locale,
     modifier: Modifier = Modifier,
-    locale: Locale = LocalConfiguration.current.getDefaultLocale()
 ) {
     val iconRotation by animateFloatAsState(targetValue = if (dropdownOpen) 0F else 180f)
 
@@ -451,8 +452,8 @@ internal fun MonthYearSelection(
  *
  * @param month a [Month] to display
  * @param onDayClick called when a day is clicked within this [Month]
- * @param modifier a [Modifier]
  * @param locale [Locale] which to take first day of week from
+ * @param modifier a [Modifier]
  * @param today today
  * @param showDaysAbbreviations whether to show the row with day names abbreviations atop the grid
  */
@@ -460,8 +461,8 @@ internal fun MonthYearSelection(
 internal fun Month(
     month: YearMonth,
     onDayClick: (LocalDate) -> Unit,
+    locale: Locale,
     modifier: Modifier = Modifier,
-    locale: Locale = LocalConfiguration.current.getDefaultLocale(),
     today: LocalDate = LocalDate.now(),
     showDaysAbbreviations: Boolean = true,
     highlightToday: Boolean = true,

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
@@ -65,10 +65,12 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import com.marosseleng.compose.material3.datetimepickers.R
+import com.marosseleng.compose.material3.datetimepickers.common.domain.getDefaultLocale
 import com.marosseleng.compose.material3.datetimepickers.common.domain.withNotNull
 import com.marosseleng.compose.material3.datetimepickers.common.ui.BidirectionalInfiniteListHandler
 import com.marosseleng.compose.material3.datetimepickers.date.domain.DatePickerColors
@@ -111,7 +113,7 @@ internal fun ModalDatePicker(
     selectedDate: LocalDate?,
     onDayClick: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
-    locale: Locale = Locale.getDefault(),
+    locale: Locale = LocalConfiguration.current.getDefaultLocale(),
     today: LocalDate = LocalDate.now(),
     showDaysAbbreviations: Boolean = true,
     highlightToday: Boolean = true,
@@ -189,7 +191,7 @@ internal fun ModalDatePicker(
                         MonthSelection(
                             modifier = Modifier
                                 .heightIn(max = 336.dp),
-                            locale = Locale.getDefault(),
+                            locale = LocalConfiguration.current.getDefaultLocale(),
                             selectedMonth = yearMonth.month,
                             onMonthClick = {
                                 yearMonth = YearMonth.of(yearMonth.year, it)
@@ -216,7 +218,7 @@ internal fun MonthSelection(
     selectedMonth: Month,
     onMonthClick: (Month) -> Unit,
     modifier: Modifier = Modifier,
-    locale: Locale = Locale.getDefault()
+    locale: Locale = LocalConfiguration.current.getDefaultLocale()
 ) {
     val months by remember(Unit) {
         mutableStateOf(Month.values().map { it.getDisplayName(TextStyle.FULL_STANDALONE, locale) })
@@ -377,7 +379,7 @@ internal fun MonthYearSelection(
     onMonthClick: () -> Unit,
     onNextMonthClick: () -> Unit,
     modifier: Modifier = Modifier,
-    locale: Locale = Locale.getDefault()
+    locale: Locale = LocalConfiguration.current.getDefaultLocale()
 ) {
     val iconRotation by animateFloatAsState(targetValue = if (dropdownOpen) 0F else 180f)
 
@@ -459,7 +461,7 @@ internal fun Month(
     month: YearMonth,
     onDayClick: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
-    locale: Locale = Locale.getDefault(),
+    locale: Locale = LocalConfiguration.current.getDefaultLocale(),
     today: LocalDate = LocalDate.now(),
     showDaysAbbreviations: Boolean = true,
     highlightToday: Boolean = true,
@@ -487,7 +489,7 @@ internal fun Month(
                         contentAlignment = Alignment.Center
                     ) {
                         val dayAbbr = DayOfWeek.of(((globalFirstDayIndex - 1 + dayIndex) % 7) + 1)
-                            .getDisplayName(TextStyle.NARROW, Locale.getDefault())
+                            .getDisplayName(TextStyle.NARROW, locale)
                         Text(
                             text = dayAbbr,
                             style = LocalDatePickerTypography.current.weekDay,

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/dialog/DatePickerDialog.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/dialog/DatePickerDialog.kt
@@ -32,11 +32,13 @@ import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.DialogProperties
+import com.marosseleng.compose.material3.datetimepickers.common.domain.getDefaultLocale
 import com.marosseleng.compose.material3.datetimepickers.date.domain.DatePickerColors
 import com.marosseleng.compose.material3.datetimepickers.date.domain.DatePickerDefaults
 import com.marosseleng.compose.material3.datetimepickers.date.domain.DatePickerShapes
@@ -69,7 +71,7 @@ public fun DatePickerDialog(
     onDateChange: (LocalDate) -> Unit,
     modifier: Modifier = Modifier,
     initialDate: LocalDate? = null,
-    locale: Locale = Locale.getDefault(),
+    locale: Locale = LocalConfiguration.current.getDefaultLocale(),
     today: LocalDate = LocalDate.now(),
     showDaysAbbreviations: Boolean = true,
     highlightToday: Boolean = true,

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/HorizontalTimePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/HorizontalTimePicker.kt
@@ -65,6 +65,7 @@ import com.marosseleng.compose.material3.datetimepickers.time.ui.dialog.TimePick
 import java.text.DateFormatSymbols
 import java.time.LocalTime
 import java.util.Calendar
+import java.util.Locale
 
 /**
  * A horizontal layout for time picker.
@@ -77,6 +78,7 @@ public fun HorizontalTimePicker(
     initialTime: LocalTime,
     onTimeChange: (LocalTime) -> Unit,
     modifier: Modifier = Modifier,
+    locale: Locale = LocalConfiguration.current.getDefaultLocale(),
     is24HourFormat: Boolean = DateFormat.is24HourFormat(LocalContext.current),
     colors: TimePickerColors = TimePickerDefaults.colors,
     shapes: TimePickerShapes = TimePickerDefaults.shapes,
@@ -131,6 +133,7 @@ public fun HorizontalTimePicker(
                             onTimeChange(newTime)
                         }
                     },
+                    locale = locale,
                 )
                 Crossfade(
                     modifier = Modifier.padding(start = 64.dp, top = 8.dp, bottom = 24.dp),
@@ -209,6 +212,7 @@ internal fun VerticalClockDigits(
     onMinuteClick: () -> Unit,
     onAmClick: () -> Unit,
     onPmClick: () -> Unit,
+    locale: Locale,
     modifier: Modifier = Modifier,
 ) {
     val selectedFieldColor = LocalTimePickerColors.current.clockDigitsSelectedBackgroundColor
@@ -288,6 +292,7 @@ internal fun VerticalClockDigits(
                     amPmMode = amPmMode,
                     onAmClick = onAmClick,
                     onPmClick = onPmClick,
+                    locale = locale,
                     modifier = Modifier.padding(top = 12.dp),
                 )
             }
@@ -316,16 +321,17 @@ public fun VerticalDivider(
 
 
 /**
- * Vertical AM/PM switch for use in vertical layout.
+ * Horizontal AM/PM switch for use in horizontal layout.
  */
 @Composable
 internal fun HorizontalAmPmSwitch(
     amPmMode: AmPmMode,
     onAmClick: () -> Unit,
     onPmClick: () -> Unit,
+    locale: Locale,
     modifier: Modifier = Modifier,
 ) {
-    val amPmStrings = DateFormatSymbols.getInstance(LocalConfiguration.current.getDefaultLocale()).amPmStrings
+    val amPmStrings = DateFormatSymbols.getInstance(locale).amPmStrings
     val selectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedBackgroundColor
     val selectedFontColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedTextColor
     val unselectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldUnselectedBackgroundColor

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/HorizontalTimePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/HorizontalTimePicker.kt
@@ -44,10 +44,12 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.marosseleng.compose.material3.datetimepickers.common.domain.getDefaultLocale
 import com.marosseleng.compose.material3.datetimepickers.common.domain.withNotNull
 import com.marosseleng.compose.material3.datetimepickers.time.domain.AmPmMode
 import com.marosseleng.compose.material3.datetimepickers.time.domain.ClockDialMode
@@ -63,7 +65,6 @@ import com.marosseleng.compose.material3.datetimepickers.time.ui.dialog.TimePick
 import java.text.DateFormatSymbols
 import java.time.LocalTime
 import java.util.Calendar
-import java.util.Locale
 
 /**
  * A horizontal layout for time picker.
@@ -324,7 +325,7 @@ internal fun HorizontalAmPmSwitch(
     onPmClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val amPmStrings = DateFormatSymbols.getInstance(Locale.getDefault()).amPmStrings
+    val amPmStrings = DateFormatSymbols.getInstance(LocalConfiguration.current.getDefaultLocale()).amPmStrings
     val selectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedBackgroundColor
     val selectedFontColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedTextColor
     val unselectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldUnselectedBackgroundColor

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/TimePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/TimePicker.kt
@@ -56,10 +56,12 @@ import androidx.compose.ui.draw.rotate
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
+import com.marosseleng.compose.material3.datetimepickers.common.domain.getDefaultLocale
 import com.marosseleng.compose.material3.datetimepickers.common.domain.roundToNearest
 import com.marosseleng.compose.material3.datetimepickers.common.domain.withNotNull
 import com.marosseleng.compose.material3.datetimepickers.time.domain.AmPmMode
@@ -75,7 +77,6 @@ import com.marosseleng.compose.material3.datetimepickers.time.domain.getHour
 import java.text.DateFormatSymbols
 import java.time.LocalTime
 import java.util.Calendar
-import java.util.Locale
 import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.roundToInt
@@ -321,7 +322,7 @@ internal fun VerticalAmPmSwitch(
     onAmClick: () -> Unit,
     onPmClick: () -> Unit,
 ) {
-    val amPmStrings = DateFormatSymbols.getInstance(Locale.getDefault()).amPmStrings
+    val amPmStrings = DateFormatSymbols.getInstance(LocalConfiguration.current.getDefaultLocale()).amPmStrings
     val selectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedBackgroundColor
     val selectedFontColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedTextColor
     val unselectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldUnselectedBackgroundColor

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/TimePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/TimePicker.kt
@@ -77,6 +77,7 @@ import com.marosseleng.compose.material3.datetimepickers.time.domain.getHour
 import java.text.DateFormatSymbols
 import java.time.LocalTime
 import java.util.Calendar
+import java.util.Locale
 import kotlin.math.PI
 import kotlin.math.atan2
 import kotlin.math.roundToInt
@@ -85,10 +86,11 @@ import kotlin.math.sqrt
 /**
  * Displays a time picker.
  *
- * @param modifier [Modifier] passed from parent.
- * @param is24HourFormat whether or not the time picker should be shown in 24-hour format.
- * @param time time to display.
+ * @param initialTime initial time to display.
  * @param onTimeChange function called each time the time is changed.
+ * @param modifier [Modifier] passed from parent.
+ * @param locale [Locale] used to translate AM/PM strings
+ * @param is24HourFormat whether or not the time picker should be shown in 24-hour format.
  */
 @ExperimentalMaterial3Api
 @Composable
@@ -96,6 +98,7 @@ public fun TimePicker(
     initialTime: LocalTime,
     onTimeChange: (LocalTime) -> Unit,
     modifier: Modifier = Modifier,
+    locale: Locale = LocalConfiguration.current.getDefaultLocale(),
     is24HourFormat: Boolean = DateFormat.is24HourFormat(LocalContext.current),
     colors: TimePickerColors = TimePickerDefaults.colors,
     shapes: TimePickerShapes = TimePickerDefaults.shapes,
@@ -151,6 +154,7 @@ public fun TimePicker(
                             onTimeChange(newTime)
                         }
                     },
+                    locale = locale,
                 )
                 Crossfade(
                     modifier = Modifier
@@ -229,6 +233,7 @@ internal fun HorizontalClockDigits(
     onMinuteClick: () -> Unit,
     onAmClick: () -> Unit,
     onPmClick: () -> Unit,
+    locale: Locale,
     modifier: Modifier = Modifier,
 ) {
     val selectedFieldColor = LocalTimePickerColors.current.clockDigitsSelectedBackgroundColor
@@ -307,6 +312,7 @@ internal fun HorizontalClockDigits(
                     amPmMode = amPmMode,
                     onAmClick = onAmClick,
                     onPmClick = onPmClick,
+                    locale = locale,
                 )
             }
         }
@@ -321,8 +327,9 @@ internal fun VerticalAmPmSwitch(
     amPmMode: AmPmMode,
     onAmClick: () -> Unit,
     onPmClick: () -> Unit,
+    locale: Locale,
 ) {
-    val amPmStrings = DateFormatSymbols.getInstance(LocalConfiguration.current.getDefaultLocale()).amPmStrings
+    val amPmStrings = DateFormatSymbols.getInstance(locale).amPmStrings
     val selectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedBackgroundColor
     val selectedFontColor = LocalTimePickerColors.current.amPmSwitchFieldSelectedTextColor
     val unselectedFieldColor = LocalTimePickerColors.current.amPmSwitchFieldUnselectedBackgroundColor

--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/dialog/TimePickerDialog.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/time/ui/dialog/TimePickerDialog.kt
@@ -32,10 +32,12 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.window.DialogProperties
+import com.marosseleng.compose.material3.datetimepickers.common.domain.getDefaultLocale
 import com.marosseleng.compose.material3.datetimepickers.time.domain.TimePickerColors
 import com.marosseleng.compose.material3.datetimepickers.time.domain.TimePickerDefaults
 import com.marosseleng.compose.material3.datetimepickers.time.domain.TimePickerShapes
@@ -43,6 +45,7 @@ import com.marosseleng.compose.material3.datetimepickers.time.domain.TimePickerT
 import com.marosseleng.compose.material3.datetimepickers.time.domain.noSeconds
 import com.marosseleng.compose.material3.datetimepickers.time.ui.TimePicker
 import java.time.LocalTime
+import java.util.Locale
 
 /**
  * Dialog containing time picker. This is an example minimal implementations.
@@ -61,6 +64,7 @@ public fun TimePickerDialog(
     onTimeChange: (LocalTime) -> Unit,
     modifier: Modifier = Modifier,
     initialTime: LocalTime = LocalTime.now().noSeconds(),
+    locale: Locale = LocalConfiguration.current.getDefaultLocale(),
     is24HourFormat: Boolean = DateFormat.is24HourFormat(LocalContext.current),
     colors: TimePickerColors = TimePickerDefaults.colors,
     shapes: TimePickerShapes = TimePickerDefaults.shapes,
@@ -98,6 +102,7 @@ public fun TimePickerDialog(
             TimePicker(
                 initialTime = initialTime,
                 onTimeChange = { time = it },
+                locale = locale,
                 is24HourFormat = is24HourFormat,
                 colors = colors,
                 shapes = shapes,


### PR DESCRIPTION
Currently, there are different way to provide Locale for different `Locale`-depending strings.

This PR ensures there is only a single way to provide the "default" Locale used by the consumer app.

Also, API changes are introduced so that the default value for `Locale` parameters are passed only for the top-level composables.