### PR TITLE
Fix MonthYearSelection offset.

### DIFF
--- a/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
+++ b/datetimepickers/src/main/java/com/marosseleng/compose/material3/datetimepickers/date/ui/DatePicker.kt
@@ -150,7 +150,7 @@ internal fun ModalDatePicker(
                 },
                 onNextMonthClick = { yearMonth = yearMonth.plusMonths(1L) },
                 locale = locale,
-                modifier = Modifier.offset(x = -16.dp),
+                modifier = Modifier,
             )
 
             Crossfade(
@@ -392,6 +392,7 @@ internal fun MonthYearSelection(
     ) {
         Row(
             modifier = Modifier
+                .offset(x = -16.dp)
                 .height(32.dp)
                 .clip(RoundedCornerShape(percent = 50))
                 .clickable(onClick = onMonthClick),


### PR DESCRIPTION
This PR fixes offset applied on the whole row instead of just the month-year dropdown.